### PR TITLE
Add workflow for automatic deployment on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,18 @@
-name: Release
-on: [push]
-# on:
-#   release:
-#     types: [published]
+name: Publish
+on:
+  release:
+    types: [published]
 
 jobs:
   release:
-    name: Release
+    name: Publish on crates.io
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: publish
-          args: --token ${{ secrets.CARGO_CRATES_TOKEN }} --dry-run
+          args: --token ${{ secrets.CARGO_CRATES_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+on: [push]
+# on:
+#   release:
+#     types: [published]
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --token ${{ secrets.CARGO_CRATES_TOKEN }} --dry-run


### PR DESCRIPTION
Automatically release as crate on crates.io when a new Github release has been created.